### PR TITLE
maven-source-plugin execution: create-source-jar -> attach-sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1987,7 +1987,7 @@
           </configuration>
           <executions>
             <execution>
-              <id>create-source-jar</id>
+              <id>attach-sources</id>
               <goals>
                 <goal>jar-no-fork</goal>
                 <goal>test-jar-no-fork</goal>


### PR DESCRIPTION
Otherwise the effective-pom ends up with a create-source-jar execution and an attach-sources execution, which causes the deploy plugin to attempt and fail to upload the same attachedArtifacts more than once.