### PR TITLE
Set useReleaseProfile to false in maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2016,6 +2016,9 @@
 	<plugin>
           <artifactId>maven-release-plugin</artifactId>
           <version>2.5.2</version>
+          <configuration>
+            <useReleaseProfile>false</useReleaseProfile>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
To avoid trying to add duplicate sources and javadocs to the released artifact.