### PR TITLE
SKIPME: Add logic to get the size estimation from Hadoop filesystem.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
@@ -197,10 +197,11 @@ private[sql] case class EnsureRequirements(sqlContext: SQLContext) extends Rule[
   private def numPartitions: Int =
     Option(sqlContext.sparkContext.getLocalProperty("spark.sql.shuffle.partitions")).map { str =>
       try {
+        logDebug(s"Use spark.sql.shuffle.partitions = $str from local property")
         str.toInt
       } catch {
         case _: NumberFormatException =>
-          logError(s"Shuffle partition should be number, actual value $str")
+          logError(s"spark.sql.shuffle.partitions from local property value $str, expect number")
           sqlContext.conf.numShufflePartitions
       }
     }.getOrElse(sqlContext.conf.numShufflePartitions)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
@@ -194,7 +194,16 @@ case class Exchange(newPartitioning: Partitioning, child: SparkPlan) extends Una
  */
 private[sql] case class EnsureRequirements(sqlContext: SQLContext) extends Rule[SparkPlan] {
   // TODO: Determine the number of partitions.
-  private def numPartitions: Int = sqlContext.conf.numShufflePartitions
+  private def numPartitions: Int =
+    Option(sqlContext.sparkContext.getLocalProperty("spark.sql.shuffle.partitions")).map { str =>
+      try {
+        str.toInt
+      } catch {
+        case _: NumberFormatException =>
+          logError(s"Shuffle partition should be number, actual value $str")
+          sqlContext.conf.numShufflePartitions
+      }
+    }.getOrElse(sqlContext.conf.numShufflePartitions)
 
   /**
    * Given a required distribution, returns a partitioning that satisfies that distribution.

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -440,4 +440,17 @@ abstract class HadoopFileSelector {
    *         to this table.
    */
   def selectFiles(tableName: String, fs: FileSystem, basePath: Path): Option[Seq[Path]]
+
+  /**
+   * Get size in bytes of files constituting a table from the given base path according to the
+   * client's custom algorithm. This is only applied to non-partitioned tables.
+   * @param tableName table name to select files for. This is the exact table name specified
+   *                  in the query, not a "preprocessed" file name returned by the user-defined
+   *                  function registered via [[HiveContext.setTableNamePreprocessor]].
+   * @param fs the filesystem containing the table
+   * @param basePath base path of the table in the filesystem
+   * @return the total sum of file size in bytes, or [[None]] if the custom file selection
+   *         algorithm does not apply to this table.
+   */
+  def getFilesSizeInBytes(tableName: String, fs: FileSystem, basePath: Path): Option[Long]
 }


### PR DESCRIPTION
When we do the size estimation in joining, spark calls hive metastore to get the size in bytes. Add callback so that we will call hadoop file system directly. 

The initial attempt to use the shuffle partition size in local properties. If we can get the adaptive execution work, then this work is redundant. 

@markhamstra @mbautin 