### PR TITLE
SPY-885: CSD's FileSelector is not applied for Parquet in SparkSQL query

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.hive
 
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
 import com.google.common.base.Objects
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import org.apache.hadoop.fs.Path
@@ -26,6 +29,7 @@ import org.apache.hadoop.hive.metastore.Warehouse
 import org.apache.hadoop.hive.metastore.api.FieldSchema
 import org.apache.hadoop.hive.ql.metadata._
 import org.apache.hadoop.hive.ql.plan.TableDesc
+
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.analysis.{Catalog, MultiInstanceRelation, OverrideCatalog}
 import org.apache.spark.sql.catalyst.expressions._
@@ -40,9 +44,6 @@ import org.apache.spark.sql.hive.client._
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{AnalysisException, SQLContext, SaveMode}
-
-import scala.collection.JavaConversions._
-import scala.collection.mutable
 
 private[hive] case class HiveSerDe(
     inputFormat: Option[String] = None,
@@ -531,7 +532,7 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
    * The value of locationOpt will be returned as single element sequence if
    * 1. the hadoopFileSelector is not defined or
    * 2. locationOpt is not defined or
-   * 3. the selected directories is empty.
+   * 3. the selected directories are empty.
    *
    * Otherwise, the non-empty selected directories will be returned.
    */
@@ -549,9 +550,9 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
         selectedPath <- selectedPaths
         if selectedPath.getFileSystem(hive.hiveconf).isDirectory(selectedPath)
       } yield selectedPath.toString
-      if !selectedDir.isEmpty
+      if selectedDir.nonEmpty
     } yield selectedDir
-    inputPaths.getOrElse(Seq(locationOpt.getOrElse(null)))
+    inputPaths.getOrElse(Seq(locationOpt.orNull))
   }
 
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -17,9 +17,6 @@
 
 package org.apache.spark.sql.hive
 
-import scala.collection.JavaConversions._
-import scala.collection.mutable
-
 import com.google.common.base.Objects
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import org.apache.hadoop.fs.Path
@@ -29,7 +26,6 @@ import org.apache.hadoop.hive.metastore.Warehouse
 import org.apache.hadoop.hive.metastore.api.FieldSchema
 import org.apache.hadoop.hive.ql.metadata._
 import org.apache.hadoop.hive.ql.plan.TableDesc
-
 import org.apache.spark.Logging
 import org.apache.spark.sql.catalyst.analysis.{Catalog, MultiInstanceRelation, OverrideCatalog}
 import org.apache.spark.sql.catalyst.expressions._
@@ -44,6 +40,9 @@ import org.apache.spark.sql.hive.client._
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{AnalysisException, SQLContext, SaveMode}
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
 
 private[hive] case class HiveSerDe(
     inputFormat: Option[String] = None,
@@ -508,7 +507,9 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
 
       parquetRelation
     } else {
-      val paths = Seq(metastoreRelation.hiveQlTable.getDataLocation.toString)
+      val paths = selectParquetLocationDirectories(
+        metastoreRelation.tableName,
+        Option(metastoreRelation.hiveQlTable.getDataLocation.toString))
 
       val cached = getCached(tableIdentifier, paths, metastoreSchema, None)
       val parquetRelation = cached.getOrElse {
@@ -523,6 +524,36 @@ private[hive] class HiveMetastoreCatalog(val client: ClientInterface, hive: Hive
 
     result.copy(expectedOutputAttributes = Some(metastoreRelation.output))
   }
+
+  /**
+   * Customizing the data directory selection by using hadoopFileSelector.
+   *
+   * The value of locationOpt will be returned as single element sequence if
+   * 1. the hadoopFileSelector is not defined or
+   * 2. locationOpt is not defined or
+   * 3. the selected directories is empty.
+   *
+   * Otherwise, the non-empty selected directories will be returned.
+   */
+  private[hive] def selectParquetLocationDirectories(
+    tableName: String,
+    locationOpt: Option[String]): Seq[String] = {
+
+    val inputPaths: Option[Seq[String]] = for {
+      selector <- hive.hadoopFileSelector
+      l <- locationOpt
+      location = new Path(l)
+      fs = location.getFileSystem(hive.hiveconf)
+      selectedPaths <- selector.selectFiles(tableName, fs, location)
+      selectedDir = for {
+        selectedPath <- selectedPaths
+        if selectedPath.getFileSystem(hive.hiveconf).isDirectory(selectedPath)
+      } yield selectedPath.toString
+      if !selectedDir.isEmpty
+    } yield selectedDir
+    inputPaths.getOrElse(Seq(locationOpt.getOrElse(null)))
+  }
+
 
   override def getTables(databaseName: Option[String]): Seq[(String, Boolean)] = {
     val db = databaseName.getOrElse(client.currentDatabase)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
@@ -66,73 +66,81 @@ class ParquetLocationSelectionSuite extends DataSourceTest {
   }
 
   test(s"With Selector selecting from ${baseDir.toString}") {
-    val fullpath = (somewhere: String, sometable: String)
-    => s"${baseDir.toString}/${somewhere}/$sometable"
+    val fullpath = { (somewhere: String, sometable: String) =>
+      s"${baseDir.toString}/${somewhere}/$sometable"
+    }
 
     TestHive.setHadoopFileSelector(new HadoopFileSelector() {
-      override def getFilesSizeInBytes(tableName: String, fs: FileSystem, basePath: Path):
-      Option[Long] = Some(100L)
+      override def getFilesSizeInBytes(
+          tableName: String,
+          fs: FileSystem,
+          basePath: Path): Option[Long] = Some(100L)
 
-      override def selectFiles(sometable: String, fs: FileSystem, somewhere: Path):
-      Option[Seq[Path]] =
+      override def selectFiles(
+          sometable: String,
+          fs: FileSystem,
+          somewhere: Path): Option[Seq[Path]] = {
         Some(Seq(new Path(fullpath(somewhere.toString, sometable))))
+      }
     })
 
     // ensure directory existence for somewhere/sometable
     val somewhereSometable = new File(fullpath("somewhere", "sometable"))
     somewhereSometable.mkdirs()
     // somewhere/sometable is a directory => will be selected
-    assertResult(Seq(fullpath("somewhere", "sometable")))(
+    assertResult(Seq(fullpath("somewhere", "sometable"))) {
       hmc.selectParquetLocationDirectories("sometable", Option("somewhere"))
-    )
+    }
 
     // ensure file existence for somewhere/sometable
     somewhereSometable.delete()
     somewhereSometable.createNewFile()
     // somewhere/sometable is a file => will not be selected
-    assertResult(Seq("somewhere"))(
+    assertResult(Seq("somewhere")) {
       hmc.selectParquetLocationDirectories("otherplace", Option("somewhere"))
-    )
+    }
 
     // no location specified, none selected
-    assertResult(Seq(null))(
+    assertResult(Seq(null)){
       hmc.selectParquetLocationDirectories("sometable", Option(null))
-    )
+    }
   }
 
   test("With Selector selecting None") {
     TestHive.setHadoopFileSelector(new HadoopFileSelector() {
-      override def getFilesSizeInBytes(tableName: String, fs: FileSystem, basePath: Path):
-      Option[Long] = Some(100L)
-      override def selectFiles(tableName: String, fs: FileSystem, basePath: Path):
-      Option[Seq[Path]] =
-        None
+      override def getFilesSizeInBytes(
+          tableName: String,
+          fs: FileSystem,
+          basePath: Path): Option[Long] = Some(100L)
+
+      override def selectFiles(
+          tableName: String,
+          fs: FileSystem,
+          basePath: Path): Option[Seq[Path]] = None
     })
 
     // none selected
-    assertResult(Seq("somewhere"))(
+    assertResult(Seq("somewhere")) {
       hmc.selectParquetLocationDirectories("sometable", Option("somewhere"))
-    )
+    }
     // none selected
-    assertResult(Seq(null))(
+    assertResult(Seq(null)) {
       hmc.selectParquetLocationDirectories("sometable", Option(null))
-    )
+    }
   }
 
   test("Without Selector") {
     TestHive.unsetHadoopFileSelector()
 
     // none selected
-    assertResult(Seq("somewhere"))(
+    assertResult(Seq("somewhere")) {
       hmc.selectParquetLocationDirectories("sometable", Option("somewhere"))
-    )
+    }
     // none selected
-    assertResult(Seq(null))(
+    assertResult(Seq(null)) {
       hmc.selectParquetLocationDirectories("sometable", Option(null))
-    )
+    }
   }
-
-
 }
 
 class DataSourceWithHiveMetastoreCatalogSuite extends DataSourceTest with SQLTestUtils {
@@ -241,6 +249,5 @@ class DataSourceWithHiveMetastoreCatalogSuite extends DataSourceTest with SQLTes
         }
       }
     }
-
   }
 }


### PR DESCRIPTION
@markhamstra 
@mbautin 