### PR TITLE
Create a way to get the broadcast future from BroadcastHashJoin

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoin.scala
@@ -65,7 +65,7 @@ case class BroadcastHashJoin(
 
   private[this] val broadcastFutureInitLock = new Object()
 
-  // Use @volatile so we can read a snapshot of this value of this without locking.
+  // Use @volatile so we can read a snapshot of this without locking.
   @volatile
   private[this] var broadcastFutureValue: Option[Future[Broadcast[HashedRelation]]] = None
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoin.scala
@@ -66,7 +66,8 @@ case class BroadcastHashJoin(
   private[this] val broadcastFutureInitLock = new Object()
 
   // Use @volatile so we can read a snapshot of this value of this without locking.
-  private[this] @volatile var broadcastFutureValue: Option[Future[Broadcast[HashedRelation]]] = None
+  @volatile
+  private[this] var broadcastFutureValue: Option[Future[Broadcast[HashedRelation]]] = None
 
   // Use lazy so that we won't do broadcast when calling explain but still cache the broadcast value
   // for the same query.


### PR DESCRIPTION
This is useful for memory accounting when holding on to a lot of RDDs.

@markhamstra 