### PR TITLE
SKIPME: Apply different memory fraction configuration on driver and executor

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -351,7 +351,7 @@ object SparkEnv extends Logging {
       if (useLegacyMemoryManager) {
         new StaticMemoryManager(conf, numUsableCores)
       } else {
-        UnifiedMemoryManager(conf, numUsableCores)
+        UnifiedMemoryManager(conf, numUsableCores, isDriver)
       }
 
     val blockTransferService = new NettyBlockTransferService(conf, securityManager, numUsableCores)


### PR DESCRIPTION
This is an attempt to apply different memory fraction configuration on driver and executor. This approach passes in a flag to indicate whether the configuration is for driver, if it is for driver, it will look for a configuration from spark conf, otherwise, it will use the spark.memory.fraction setting. 

I have tested this out on a single node cluster. I will also look for junit tests to add if this approach sounds reasonable. 