### PR TITLE
SPY-1302: Attempt to disable adaptive execution for joining

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -242,6 +242,10 @@ private[spark] object SQLConf {
     defaultValue = Some(false),
     doc = "When true, enable adaptive query execution.")
 
+  val ADAPTIVE_EXECUTION_DISABLED_FOR_JOINING = booleanConf("spark.sql.adaptive.disabled.for.join",
+    defaultValue = Some(false),
+    doc = "When true, disable adaptive query execution when performing joining.")
+
   val SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS =
     intConf("spark.sql.adaptive.minNumPostShufflePartitions",
       defaultValue = Some(-1),
@@ -507,6 +511,9 @@ private[sql] class SQLConf extends Serializable with CatalystConf {
     getConf(SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE)
 
   private[spark] def adaptiveExecutionEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_ENABLED)
+
+  private[spark] def adaptiveExecutionDisabledForJoining: Boolean =
+    getConf(ADAPTIVE_EXECUTION_DISABLED_FOR_JOINING)
 
   private[spark] def minNumPostShufflePartitions: Int =
     getConf(SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Exchange.scala
@@ -275,6 +275,7 @@ private[sql] case class EnsureRequirements(sqlContext: SQLContext) extends Rule[
 
   private def targetPostShuffleInputSize: Long = sqlContext.conf.targetPostShuffleInputSize
 
+  // TODO: Should we disable this from local property or from configuration?
   private def adaptiveExecutionEnabled: Boolean = sqlContext.conf.adaptiveExecutionEnabled
 
   private def adaptiveExecutionDisabledForJoin: Boolean =
@@ -481,11 +482,11 @@ private[sql] case class EnsureRequirements(sqlContext: SQLContext) extends Rule[
     // Once we finish https://issues.apache.org/jira/browse/SPARK-10665,
     // we can first add Exchanges and then add coordinator once we have a DAG of query fragments.
 
-    // We have observed some performance degrading when enabling adaptive execution in performing
-    // joining. When doing joining, it is hard to predict how many results it will generate.
-    // Sometimes the estimation is within the limit of the postShuffleSize estimation, and it causes
-    // only one partition and makes the performance bad. We will disable adaptive execution for
-    // joining now till we figure out a better way of estimation
+    // We have observed some performance issue when enabling adaptive execution in performing
+    // joining. It is hard to predict how many results the joining will produce. When the estimation
+    // from previous stage is within the postShuffleSize estimation, it will produce only one
+    // partition and makes the performance bad. We will disable adaptive execution for
+    // joining now till we figure out a better way of size estimation in joining.
     val disableAdaptiveExecutionForJoin =
       (operator.isInstanceOf[SortMergeJoin] || operator.isInstanceOf[SortMergeOuterJoin]) &&
         adaptiveExecutionEnabled && adaptiveExecutionDisabledForJoin

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExchangeCoordinatorSuite.scala
@@ -18,11 +18,13 @@
 package org.apache.spark.sql.execution
 
 import org.scalatest.BeforeAndAfterAll
-
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.TestSQLContext
 import org.apache.spark.sql._
-import org.apache.spark.{SparkFunSuite, SparkContext, SparkConf, MapOutputStatistics}
+import org.apache.spark.sql.execution.joins.{SortMergeJoin, SortMergeOuterJoin}
+import org.apache.spark.{MapOutputStatistics, SparkConf, SparkContext, SparkFunSuite}
+
+import scala.collection.mutable
 
 class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
 
@@ -251,7 +253,8 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
   def withSQLContext(
       f: SQLContext => Unit,
       targetNumPostShufflePartitions: Int,
-      minNumPostShufflePartitions: Option[Int]): Unit = {
+      minNumPostShufflePartitions: Option[Int],
+      adaptiveExecutionDisabledForJoin: Boolean = false): Unit = {
     val sparkConf =
       new SparkConf(false)
         .setMaster("local[*]")
@@ -263,6 +266,9 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
         .set(
           SQLConf.SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE.key,
           targetNumPostShufflePartitions.toString)
+    if (adaptiveExecutionDisabledForJoin) {
+      sparkConf.set(SQLConf.ADAPTIVE_EXECUTION_DISABLED_FOR_JOINING.key, "true")
+    }
     minNumPostShufflePartitions match {
       case Some(numPartitions) =>
         sparkConf.set(SQLConf.SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS.key, numPartitions.toString)
@@ -474,6 +480,80 @@ class ExchangeCoordinatorSuite extends SparkFunSuite with BeforeAndAfterAll {
       }
 
       withSQLContext(test, 6144, minNumPostShufflePartitions)
+    }
+
+    test(s"adaptive execution disabled for joining: complex query 3$testNameNote") {
+      val test = { sqlContext: SQLContext =>
+        val df1 =
+          sqlContext
+            .range(0, 1000, 1, numInputPartitions)
+            .selectExpr("id % 500 as key1", "id as value1")
+            .groupBy("key1")
+            .count
+            .toDF("key1", "cnt1")
+        val df2 =
+          sqlContext
+            .range(0, 1000, 1, numInputPartitions)
+            .selectExpr("id % 500 as key2", "id as value2")
+
+        val join =
+          df1
+            .join(df2, col("key1") === col("key2"))
+            .select(col("key1"), col("cnt1"), col("value2"))
+
+        // Check the answer first.
+        val expectedAnswer =
+          sqlContext
+            .range(0, 1000)
+            .selectExpr("id % 500 as key", "2 as cnt", "id as value")
+        checkAnswer(
+          join,
+          expectedAnswer.collect())
+
+        // Verify that there is adaptive execution is disabled for SortMergeOuterJoin and SortMergeJoin
+        // but not for others
+        val executedPlan = join.queryExecution.executedPlan
+        val verified = new mutable.HashSet[SparkPlan]
+        val waitingToVerify = new mutable.Stack[(SparkPlan, Boolean)]
+        def verify(plan: SparkPlan, childOfJoin: Boolean): Unit = {
+          if (!verified(plan)) {
+            verified += plan
+            plan match {
+              case SortMergeOuterJoin(leftKeys, rightKeys, joinType, condition, left, right) =>
+                waitingToVerify.push((left, true))
+                waitingToVerify.push((right, true))
+              case SortMergeJoin(leftKeys, rightKeys, left, right) =>
+                waitingToVerify.push((left, true))
+                waitingToVerify.push((right, true))
+              case Exchange(newPartitioning, child, coordinator) =>
+                if (childOfJoin) {
+                  assert(coordinator isEmpty)
+                  waitingToVerify.push((child, false))
+                } else {
+                  minNumPostShufflePartitions match {
+                    case Some(numPartitions) =>
+                      assert(coordinator.isDefined)
+                      assert(newPartitioning.numPartitions === 5)
+                    case None =>
+                      assert(coordinator.isDefined)
+                  }
+                  waitingToVerify.push((child, false))
+                }
+              case _ =>
+                plan.children.foreach { child =>
+                  waitingToVerify.push((child, childOfJoin))
+                }
+            }
+          }
+        }
+        waitingToVerify.push((executedPlan, false))
+        while(waitingToVerify.nonEmpty) {
+          val (plan, childOfJoin) = waitingToVerify.pop()
+          verify(plan, childOfJoin)
+        }
+      }
+
+      withSQLContext(test, 6144, minNumPostShufflePartitions, true)
     }
   }
 }


### PR DESCRIPTION
This is an attempt to disable adaptive execution for joining as we have observed that it can cause some performance issue in joining. 

Note: If we want to disable it per org, we may need to do it from local property. For the proof of concept, I put the flag in the spark configuration. 