### PR TITLE
SPY-1407: Ask DagScheduler to clean up executors which has never been used

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -271,8 +271,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           // SPARK-15262: If an executor is still alive even after the scheduler has removed
           // its metadata, we may receive a heartbeat from that executor and tell its block
           // manager to reregister itself. If that happens, the block manager master will know
-          // about the executor, but the scheduler will not. Therefore, we should remove the
-          // executor from the block manager when we hit this case.
+          // about the executor, but the scheduler will not. (The same state will occur if an
+          // executor has been dynamically allocated but never assigned any task: SPARK-21876.)
+          // Therefore, we should remove the executor from the block manager when we hit this case.
           scheduler.sc.env.blockManager.master.removeExecutorAsync(executorId)
           logInfo(s"Asked to remove non-existent executor $executorId")
       }


### PR DESCRIPTION
We have observed excessive error message from our spark application driver. We have dynamic resource allocation enabled and set spark.dynamicAllocation.executorIdleTimeout = 600s

When an executor is created, but no tasks has been created on it. After 600 seconds, it will be killed. However, since no tasks has been launched on it, this executor doesn't exist in neither executorIdToRunningTaskIds no executorIdToHost. As a result it is not cleaned from the  BlockManagerMasterEndpoint blockManagerInfo map. In every GC, un-referenced RDDs, shuffle and broadcast will be cleaned, and all RPC endpoints from blockManagerInfo map will receive the requests. Because the executor is killed, but not cleaned up properly, the driver will receive an error like this ' org.apache.spark.network.client.TransportClient: Failed to send RPC 7330089430728626490 to ip-xxx/xxx:33430: java.nio.channels.ClosedChannelException'. 