### PR TITLE
SPY-1453: second attempt

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.execution.datasources
 
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.MultiInstanceRelation
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{AttributeMap, AttributeReference}
@@ -70,6 +69,12 @@ case class LogicalRelation(
     case _ =>  // Do nothing.
   }
 
+  /**
+   * SPY-1453
+   * csd's version range information from identifier has to be
+   * present in simpleString for caching that requires
+   * logical plan matching to work.
+   */
   override def simpleString: String = {
     s"Relation[${Utils.truncatedString(output, ",")}] $relation " +
       s"${catalogTable.map(_.identifier.identifier).getOrElse("")}"

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/parquetSuites.scala
@@ -385,7 +385,7 @@ class ParquetMetastoreSuite extends ParquetPartitioningTest {
     }
   }
 
-  ignore("SPARK-7749: non-partitioned metastore Parquet table lookup should use cached relation") {
+  test("SPARK-7749: non-partitioned metastore Parquet table lookup should use cached relation") {
     withTable("nonPartitioned") {
       sql(
         """
@@ -454,7 +454,7 @@ class ParquetMetastoreSuite extends ParquetPartitioningTest {
       .getCachedDataSourceTable(table)
   }
 
-  ignore("Caching converted data source Parquet Relations") {
+  test("Caching converted data source Parquet Relations") {
     def checkCached(tableIdentifier: TableIdentifier): Unit = {
       // Converted test_parquet should be cached.
       getCachedDataSourceTable(tableIdentifier) match {


### PR DESCRIPTION
- redo fix SPY-1453
- fixed LogicalRelation.simpleString
- re-enable parquetSuites version tests