### PR TITLE
Adds hash to get correct download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,14 +48,15 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK 1
 
 # JAVA
 ARG JAVA_MAJOR_VERSION=8
-ARG JAVA_UPDATE_VERSION=92
-ARG JAVA_BUILD_NUMBER=14
+ARG JAVA_UPDATE_VERSION=151
+ARG JAVA_BUILD_NUMBER=12
+ARG JAVA_BUILD_HASH=e758a0de34e24606bca991d704f6dcbf
 ENV JAVA_HOME /usr/jdk1.${JAVA_MAJOR_VERSION}.0_${JAVA_UPDATE_VERSION}
 
 ENV PATH $PATH:$JAVA_HOME/bin
 RUN curl -sL --retry 3 --insecure \
   --header "Cookie: oraclelicense=accept-securebackup-cookie;" \
-  "http://download.oracle.com/otn-pub/java/jdk/${JAVA_MAJOR_VERSION}u${JAVA_UPDATE_VERSION}-b${JAVA_BUILD_NUMBER}/server-jre-${JAVA_MAJOR_VERSION}u${JAVA_UPDATE_VERSION}-linux-x64.tar.gz" \
+  "http://download.oracle.com/otn-pub/java/jdk/${JAVA_MAJOR_VERSION}u${JAVA_UPDATE_VERSION}-b${JAVA_BUILD_NUMBER}/${JAVA_BUILD_HASH}/server-jre-${JAVA_MAJOR_VERSION}u${JAVA_UPDATE_VERSION}-linux-x64.tar.gz" \
   | gunzip \
   | tar x -C /usr/ \
   && ln -s $JAVA_HOME /usr/java \


### PR DESCRIPTION
This just updates the java version and adds a requisite hash to get this to build again. It (the hash) was required for me to build a new 1.6.3-11 version.