### PR TITLE
SPY-1743: avoid excessive/redundant calls to FileSystem.isDirectory

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreCatalogSuite.scala
@@ -105,14 +105,6 @@ class ParquetLocationSelectionSuite extends QueryTest with SQLTestUtils with Tes
       hmc.selectParquetLocationDirectories("sometable", Option("somewhere"))
     }
 
-    // ensure file existence for somewhere/sometable
-    somewhereSometable.delete()
-    somewhereSometable.createNewFile()
-    // somewhere/sometable is a file => will not be selected
-    assertResult(Seq("somewhere")) {
-      hmc.selectParquetLocationDirectories("otherplace", Option("somewhere"))
-    }
-
     // no location specified, none selected
     assertResult(Seq(null)){
       hmc.selectParquetLocationDirectories("sometable", Option(null))


### PR DESCRIPTION
this is performance fix backported from spark-2.2. 
issuing in a loop FileSystem.isDirectory(), which results in hdfs remote calls, is a killer for performance and scalability on driver.
 
we can safely assume that a HadoopFileSelector always returns results ready to be used.
