### PR TITLE
SPY-1407: Ask DagScheduler to clean up executors that has never been used

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -324,8 +324,9 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
           // SPARK-15262: If an executor is still alive even after the scheduler has removed
           // its metadata, we may receive a heartbeat from that executor and tell its block
           // manager to reregister itself. If that happens, the block manager master will know
-          // about the executor, but the scheduler will not. Therefore, we should remove the
-          // executor from the block manager when we hit this case.
+          // about the executor, but the scheduler will not. (The same state will occur if an
+          // executor has been dynamically allocated but never assigned any task: SPARK-21876.)
+          // Therefore, we should remove the executor from the block manager when we hit this case.
           scheduler.sc.env.blockManager.master.removeExecutorAsync(executorId)
           logInfo(s"Asked to remove non-existent executor $executorId")
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When an executor is removed but no tasks has ever been launched on it, we need to ask DagScheduler to clean it up. Please refer to https://unlockdata.jira.com/browse/SPY-1407 for more details about this issue.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
