### PR TITLE
APP-1086: Fix typing, use BiConsumer subclass for iteration

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/InMemoryStore.java
@@ -107,16 +107,6 @@ public class InMemoryStore implements KVStore {
     inMemoryLists.clear();
   }
 
-  @Override
-  public <T> int countingRemoveIf(Class<T> type, Predicate<? super T> filter) {
-    InstanceList<T> list = inMemoryLists.get(type);
-
-    if (list != null) {
-      return list.countingRemoveIf(filter);
-    }
-    return 0;
-  }
-
   @SuppressWarnings("unchecked")
   @Override
   public <T> boolean removeAllByKeys(Class<T> type, String index, Collection keys) {
@@ -209,12 +199,6 @@ public class InMemoryStore implements KVStore {
 
     KVTypeInfo.Accessor getIndexAccessor(String indexName) {
       return ti.getAccessor(indexName);
-    }
-
-    int countingRemoveIf(Predicate<? super T> filter) {
-      CountingRemoveIfForEach<T> callback = new CountingRemoveIfForEach<>(data, filter);
-      data.forEach(callback);
-      return callback.count;
     }
 
     @SuppressWarnings("unchecked")

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
@@ -18,6 +18,7 @@
 package org.apache.spark.util.kvstore;
 
 import java.io.Closeable;
+import java.util.Collection;
 import java.util.function.Predicate;
 
 import org.apache.spark.annotation.Private;
@@ -131,4 +132,6 @@ public interface KVStore extends Closeable {
    * A cheaper way to remove multiple items from the KVStore
    */
   <T> int countingRemoveIf(Class<T> type, Predicate<? super T> filter) throws Exception;
+  <T> boolean removeAllByKeys(Class<T> klass, String index, Collection keys) throws Exception;
+
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
@@ -131,7 +131,5 @@ public interface KVStore extends Closeable {
   /**
    * A cheaper way to remove multiple items from the KVStore
    */
-  <T> int countingRemoveIf(Class<T> type, Predicate<? super T> filter) throws Exception;
   <T> boolean removeAllByKeys(Class<T> klass, String index, Collection keys) throws Exception;
-
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStore.java
@@ -130,5 +130,5 @@ public interface KVStore extends Closeable {
   /**
    * A cheaper way to remove multiple items from the KVStore
    */
-  abstract <T> int countingRemoveIf(Class<T> type, Predicate<? super T> filter) throws Exception;
+  <T> int countingRemoveIf(Class<T> type, Predicate<? super T> filter) throws Exception;
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreView.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreView.java
@@ -38,8 +38,6 @@ import org.apache.spark.annotation.Private;
 @Private
 public abstract class KVStoreView<T> implements Iterable<T> {
 
-  final Class<T> type;
-
   boolean ascending = true;
   String index = KVIndex.NATURAL_INDEX_NAME;
   Object first = null;
@@ -47,10 +45,6 @@ public abstract class KVStoreView<T> implements Iterable<T> {
   Object parent = null;
   long skip = 0L;
   long max = Long.MAX_VALUE;
-
-  public KVStoreView(Class<T> type) {
-    this.type = type;
-  }
 
   /**
    * Reverses the order of iteration. By default, iterates in ascending order.

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
@@ -37,7 +37,7 @@ public class KVTypeInfo {
   private final Map<String, KVIndex> indices;
   private final Map<String, Accessor> accessors;
 
-  public KVTypeInfo(Class<?> type) throws Exception {
+  public KVTypeInfo(Class<?> type) {
     this.type = type;
     this.accessors = new HashMap<>();
     this.indices = new HashMap<>();
@@ -122,7 +122,7 @@ public class KVTypeInfo {
    */
   interface Accessor {
 
-    Object get(Object instance) throws Exception;
+    Object get(Object instance) throws ReflectiveOperationException;
 
     Class getType();
   }
@@ -136,7 +136,7 @@ public class KVTypeInfo {
     }
 
     @Override
-    public Object get(Object instance) throws Exception {
+    public Object get(Object instance) throws ReflectiveOperationException {
       return field.get(instance);
     }
 
@@ -155,7 +155,7 @@ public class KVTypeInfo {
     }
 
     @Override
-    public Object get(Object instance) throws Exception {
+    public Object get(Object instance) throws ReflectiveOperationException {
       return method.invoke(instance);
     }
 

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
@@ -124,6 +124,7 @@ public class KVTypeInfo {
 
     Object get(Object instance) throws Exception;
 
+    Class getType();
   }
 
   private class FieldAccessor implements Accessor {
@@ -139,6 +140,10 @@ public class KVTypeInfo {
       return field.get(instance);
     }
 
+    @Override
+    public Class getType() {
+      return field.getType();
+    }
   }
 
   private class MethodAccessor implements Accessor {
@@ -154,6 +159,10 @@ public class KVTypeInfo {
       return method.invoke(instance);
     }
 
+    @Override
+    public Class getType() {
+      return method.getReturnType();
+    }
   }
 
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -23,7 +23,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Predicate;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -197,25 +196,6 @@ public class LevelDB implements KVStore {
         }
       }
     };
-  }
-
-  @Override
-  public <T> int countingRemoveIf(Class<T> type, Predicate<? super T> filter) throws Exception {
-    LevelDBTypeInfo.Index naturalIndex = getTypeInfo(type).naturalIndex();
-
-    List<T> list = new ArrayList<>();
-    view(type).forEach((item) ->  {
-      if (filter.test(item)) {
-        list.add(item);
-      }
-    });
-
-    for (T item: list) {
-      Object key = naturalIndex.getValue(item);
-      delete(type, key);
-    }
-
-    return list.size();
   }
 
   @Override

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -219,6 +219,23 @@ public class LevelDB implements KVStore {
   }
 
   @Override
+  public <T> boolean removeAllByKeys(Class<T> type, String index, Collection keys) throws Exception {
+    LevelDBTypeInfo.Index naturalIndex = getTypeInfo(type).naturalIndex();
+    boolean removed = false;
+    KVStoreView<T> view = view(type).index(index);
+
+    for (Object key : keys) {
+      for (T value: view.first(key).last(key)) {
+        Object itemKey = naturalIndex.getValue(value);
+        delete(type, itemKey);
+        removed = true;
+      }
+    }
+
+    return removed;
+  }
+
+  @Override
   public long count(Class<?> type) throws Exception {
     LevelDBTypeInfo.Index idx = getTypeInfo(type).naturalIndex();
     return idx.getCount(idx.end(null));

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -199,15 +199,18 @@ public class LevelDB implements KVStore {
   }
 
   @Override
-  public <T> boolean removeAllByKeys(Class<T> type, String index, Collection keys) throws Exception {
-    LevelDBTypeInfo.Index naturalIndex = getTypeInfo(type).naturalIndex();
+  public <T> boolean removeAllByKeys(
+      Class<T> klass,
+      String index,
+      Collection keys) throws Exception {
+    LevelDBTypeInfo.Index naturalIndex = getTypeInfo(klass).naturalIndex();
     boolean removed = false;
-    KVStoreView<T> view = view(type).index(index);
+    KVStoreView<T> view = view(klass).index(index);
 
     for (Object key : keys) {
       for (T value: view.first(key).last(key)) {
         Object itemKey = naturalIndex.getValue(value);
-        delete(type, itemKey);
+        delete(klass, itemKey);
         removed = true;
       }
     }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -187,11 +187,11 @@ public class LevelDB implements KVStore {
 
   @Override
   public <T> KVStoreView<T> view(Class<T> type) throws Exception {
-    return new KVStoreView<T>(type) {
+    return new KVStoreView<T>() {
       @Override
       public Iterator<T> iterator() {
         try {
-          return new LevelDBIterator<>(LevelDB.this, this);
+          return new LevelDBIterator<>(type, LevelDB.this, this);
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -45,11 +45,11 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
   private boolean closed;
   private long count;
 
-  LevelDBIterator(LevelDB db, KVStoreView<T> params) throws Exception {
+  LevelDBIterator(Class<T> type, LevelDB db, KVStoreView<T> params) throws Exception {
     this.db = db;
     this.ascending = params.ascending;
     this.it = db.db().iterator();
-    this.type = params.type;
+    this.type = type;
     this.ti = db.getTypeInfo(type);
     this.index = ti.index(params.index);
     this.max = params.max;

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/InMemoryStoreSuite.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.util.kvstore;
 
+import java.util.HashSet;
 import java.util.NoSuchElementException;
 
 import org.junit.Test;
@@ -130,6 +131,48 @@ public class InMemoryStoreSuite {
     store.write(o);
     assertEquals(o, store.read(ArrayKeyIndexType.class, o.key));
     assertEquals(o, store.view(ArrayKeyIndexType.class).index("id").first(o.id).iterator().next());
+  }
+
+  @Test
+  public void testRemoveAll() throws Exception {
+    KVStore store = new InMemoryStore();
+
+    for (int i = 0; i < 2; i++) {
+      for (int j = 0; j < 2; j++) {
+        ArrayKeyIndexType o = new ArrayKeyIndexType();
+        o.key = new int[] { i, j, 0 };
+        o.id = new String[] { "things" };
+        store.write(o);
+
+        o = new ArrayKeyIndexType();
+        o.key = new int[] { i, j, 1 };
+        o.id = new String[] { "more things" };
+        store.write(o);
+      }
+    }
+
+    ArrayKeyIndexType o = new ArrayKeyIndexType();
+    o.key = new int[] { 2, 2, 2 };
+    o.id = new String[] { "things" };
+    store.write(o);
+
+    assertEquals(9, store.count(ArrayKeyIndexType.class));
+
+    HashSet set = new HashSet();
+    set.add(new int[] {0, 0, 0});
+    set.add(new int[] { 2, 2, 2 });
+    store.removeAllByKeys(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
+    assertEquals(7, store.count(ArrayKeyIndexType.class));
+
+    set.clear();
+    set.add(new String[] { "things" });
+    store.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    assertEquals(4, store.count(ArrayKeyIndexType.class));
+
+    set.clear();
+    set.add(new String[] { "more things" });
+    store.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    assertEquals(0, store.count(ArrayKeyIndexType.class));
   }
 
   @Test

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -19,6 +19,7 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -196,6 +197,46 @@ public class LevelDBSuite {
     assertEquals(1, db.count(t.getClass()));
     assertEquals(1, db.count(t.getClass(), "name", "anotherName"));
     assertEquals(0, db.count(t.getClass(), "name", "name"));
+  }
+
+  @Test
+  public void testRemoveAll() throws Exception {
+    for (int i = 0; i < 2; i++) {
+      for (int j = 0; j < 2; j++) {
+        ArrayKeyIndexType o = new ArrayKeyIndexType();
+        o.key = new int[] { i, j, 0 };
+        o.id = new String[] { "things" };
+        db.write(o);
+
+        o = new ArrayKeyIndexType();
+        o.key = new int[] { i, j, 1 };
+        o.id = new String[] { "more things" };
+        db.write(o);
+      }
+    }
+
+    ArrayKeyIndexType o = new ArrayKeyIndexType();
+    o.key = new int[] { 2, 2, 2 };
+    o.id = new String[] { "things" };
+    db.write(o);
+
+    assertEquals(9, db.count(ArrayKeyIndexType.class));
+
+    HashSet set = new HashSet();
+    set.add(new int[] {0, 0, 0});
+    set.add(new int[] { 2, 2, 2 });
+    db.removeAllByKeys(ArrayKeyIndexType.class, KVIndex.NATURAL_INDEX_NAME, set);
+    assertEquals(7, db.count(ArrayKeyIndexType.class));
+
+    set.clear();
+    set.add(new String[] { "things" });
+    db.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    assertEquals(4, db.count(ArrayKeyIndexType.class));
+
+    set.clear();
+    set.add(new String[] { "more things" });
+    db.removeAllByKeys(ArrayKeyIndexType.class, "id", set);
+    assertEquals(0, db.count(ArrayKeyIndexType.class));
   }
 
   @Test

--- a/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
+++ b/core/src/main/scala/org/apache/spark/status/AppStatusListener.scala
@@ -994,13 +994,13 @@ private[spark] class AppStatusListener(
       }
 
       cleanupCachedQuantiles(key)
-      StageDataWrapper.asLongKey(s.info.stageId, s.info.attemptId)
-    }.toSet
+      key
+    }
 
     // Delete summaries in one pass, as deleting them for each stage is slow
     val totalSummariesDeleted = kvstore.removeAllByKeys(
       classOf[ExecutorStageSummaryWrapper],
-      "stageAsLong",
+      "stage",
       stageKeys)
 
     logDebug(s"Removed $totalSummariesDeleted summaries")
@@ -1008,7 +1008,7 @@ private[spark] class AppStatusListener(
     // Delete tasks for all stages in one pass, as deleting them for each stage individually is slow
     kvstore.removeAllByKeys(
       classOf[TaskDataWrapper],
-      TaskIndexNames.STAGE_AS_LONG,
+      TaskIndexNames.STAGE,
       stageKeys)
   }
 

--- a/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
@@ -159,8 +159,8 @@ private[spark] class ElementTrackingStore(store: KVStore, conf: SparkConf) exten
   override def countingRemoveIf[T](klass: Class[T], filter: Predicate[_ >: T]): Int =
     store.countingRemoveIf[T](klass, filter)
 
-  def removeAllByKeys[T](klass: Class[T], index: String, keys: Set[_]): Boolean =
-    removeAllByKeys(klass, index, keys.asJava)
+  def removeAllByKeys[T](klass: Class[T], index: String, keys: Iterable[_]): Boolean =
+    removeAllByKeys(klass, index, keys.asJavaCollection)
 
   override def removeAllByKeys[T](klass: Class[T], index: String, keys: Collection[_]): Boolean =
     store.removeAllByKeys(klass, index, keys)

--- a/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
+++ b/core/src/main/scala/org/apache/spark/status/ElementTrackingStore.scala
@@ -145,20 +145,6 @@ private[spark] class ElementTrackingStore(store: KVStore, conf: SparkConf) exten
     }
   }
 
-  def countingRemoveIf[T](klass: Class[T], filter: T => Boolean): Int = {
-    countingRemoveIf(
-      klass,
-      new Predicate[T]() {
-        def test(t: T): Boolean = {
-          filter(t)
-        }
-      }
-    )
-  }
-
-  override def countingRemoveIf[T](klass: Class[T], filter: Predicate[_ >: T]): Int =
-    store.countingRemoveIf[T](klass, filter)
-
   def removeAllByKeys[T](klass: Class[T], index: String, keys: Iterable[_]): Boolean =
     removeAllByKeys(klass, index, keys.asJavaCollection)
 

--- a/core/src/main/scala/org/apache/spark/status/storeTypes.scala
+++ b/core/src/main/scala/org/apache/spark/status/storeTypes.scala
@@ -99,12 +99,6 @@ private[spark] class StageDataWrapper(
   private def completionTime: Long = info.completionTime.map(_.getTime).getOrElse(-1L)
 }
 
-private[spark] object StageDataWrapper {
-  // Note: implementation assumes stageId and attemptId are positive numbers
-  def asLongKey(stageId: Int, attemptId: Int): Long =
-    stageId.toLong << 32 | attemptId
-}
-
 /**
  * Tasks have a lot of indices that are used in a few different places. This object keeps logical
  * names for these indices, mapped to short strings to save space when using a disk store.
@@ -146,7 +140,6 @@ private[spark] object TaskIndexNames {
   final val SHUFFLE_WRITE_SIZE = "sws"
   final val SHUFFLE_WRITE_TIME = "swt"
   final val STAGE = "stage"
-  final val STAGE_AS_LONG = "stgL"
   final val STATUS = "sta"
   final val TASK_INDEX = "idx"
   final val COMPLETION_TIME = "ct"
@@ -299,9 +292,6 @@ private[spark] class TaskDataWrapper(
   @JsonIgnore @KVIndex(TaskIndexNames.STAGE)
   private def stage: Array[Int] = Array(stageId, stageAttemptId)
 
-  @JsonIgnore @KVIndex(TaskIndexNames.STAGE_AS_LONG)
-  private def stageAsLong: Long = StageDataWrapper.asLongKey(stageId, stageAttemptId)
-
   @JsonIgnore @KVIndex(value = TaskIndexNames.SCHEDULER_DELAY, parent = TaskIndexNames.STAGE)
   def schedulerDelay: Long = {
     if (hasMetrics) {
@@ -382,9 +372,6 @@ private[spark] class ExecutorStageSummaryWrapper(
 
   @JsonIgnore @KVIndex("stage")
   private def stage: Array[Int] = Array(stageId, stageAttemptId)
-
-  @JsonIgnore @KVIndex("stageAsLong")
-  private def stageAsLong: Long = StageDataWrapper.asLongKey(stageId, stageAttemptId)
 
   @JsonIgnore
   def id: Array[Any] = _id

--- a/core/src/test/scala/org/apache/spark/status/ElementTrackingStorePerfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/ElementTrackingStorePerfSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.util.Utils
 import org.apache.spark.util.kvstore._
 
 class ElementTrackingStorePerfSuite extends SparkFunSuite {
-  val useLevelDB = true
+  val useLevelDB = false
 
   import config._
 
@@ -45,7 +45,7 @@ class ElementTrackingStorePerfSuite extends SparkFunSuite {
   }
 
   def initializeData(): ElementData = {
-    val count = 10000
+    val count = 1000
     val strings = (0 to 4).map { _.toString }
 
     val stages =
@@ -160,30 +160,7 @@ class ElementTrackingStorePerfSuite extends SparkFunSuite {
     }
   }
 
-  test("slightly faster n^2[logn]") {
-    setup { tracking =>
-      perfTest(tracking) {
-        val stages = tracking.view(classOf[StageDataWrapper]).asScala
-
-        stages.foreach { s =>
-          val key = Array(s.info.stageId, s.info.attemptId)
-
-          tracking.delete(s.getClass, key)
-
-          tracking.view(classOf[ExecutorStageSummaryWrapper])
-            .asScala
-            .filter { e =>
-              e.stageId == s.info.stageId && e.stageAttemptId == s.info.attemptId
-            }
-            .foreach { e =>
-              tracking.delete(e.getClass, e.id)
-            }
-        }
-      }
-    }
-  }
-
-  test("fastest n removeAllByKeys") {
+  test("removeAllByKeys") {
     setup { tracking =>
       perfTest(tracking) {
         val stages = tracking.view(classOf[StageDataWrapper]).asScala
@@ -204,7 +181,7 @@ class ElementTrackingStorePerfSuite extends SparkFunSuite {
     }
   }
 
-  test("fastest n removeAllByKeys staged") {
+  test("removeAllByKeys staged") {
     setup { tracking =>
       perfTest(tracking) {
         val allStages = tracking.view(classOf[StageDataWrapper]).asScala


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move type-safety into compile-time.  Remove runtime type checking.
Use a BiConsumer to consume elements in the map and count removals.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
